### PR TITLE
remove duplicated 'rapidjsonr' from LinkingTo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Suggests:
 VignetteBuilder: knitr
 LinkingTo: 
     Rcpp,
-    rapidjsonr,
     colourvalues,
     jsonify,
     rapidjsonr


### PR DESCRIPTION
`rapidjsonr` was listed twice in `LinkingTo`....this just removes one of them.