### PR TITLE
add R/map_location.R

### DIFF
--- a/R/map_location.R
+++ b/R/map_location.R
@@ -1,0 +1,26 @@
+# jsonlite does not support named vector locations; these functions convert
+# location arguments to numeric vectors of (mean) lon & lat
+extract_location <- function(x)
+    UseMethod("extract_location")
+
+extract_location.numeric <- function(x){
+    names(x) <- NULL
+    return(x)
+}
+
+extract_location.matrix <- function(x){
+    as.numeric(colMeans(x, na.rm = TRUE))
+}
+
+extract_location.data.frame <- function(x){ # also tibbles
+    extract_location.matrix(x)
+}
+
+extract_location.sf <- function(x){
+    g <- x[attr(x, "sf_column")] [[1]]
+    extract_location_sfc(g)
+}
+
+extract_location_sfc <- function(x){
+    colMeans(do.call(rbind, lapply(x, as.matrix)))
+}

--- a/R/mapdeck_map.R
+++ b/R/mapdeck_map.R
@@ -31,7 +31,7 @@ mapdeck <- function(
     , style = style
     , pitch = pitch
     , zoom = zoom
-    , location = location
+    , location = extract_location(location)
   )
 
   # create widget


### PR DESCRIPTION
This addresses #78 by getting rid of current warnings described there, and also enables this:
```
mapdeck (location = roads,
         zoom = 12) %>%
    add_path (data = roads,
              stroke_colour = "RIGHT_LOC")
```
The map will then be centred on the `roads` item. @tim-salabim is happy to help with the zoom-to-bbox kinda stuff necessary to establish values for `zoom`, although `deck.gl` seems to do this quite differently to `leaflet` ...?