### PR TITLE
adding viewBounds as per issue 211

### DIFF
--- a/inst/htmlwidgets/mapdeck.js
+++ b/inst/htmlwidgets/mapdeck.js
@@ -59,6 +59,21 @@ HTMLWidgets.widget({
 			      //controller: myController
 			      //onLayerHover: setTooltip
 			      onViewStateChange: ({viewState}) => {
+
+							// as per:
+							// https://github.com/uber/deck.gl/issues/3344
+							// https://github.com/SymbolixAU/mapdeck/issues/211
+			      	const viewport = new WebMercatorViewport(viewState);
+  						const nw = viewport.unproject([0, 0]);
+  						const se = viewport.unproject([viewport.width, viewport.height]);
+
+  						viewState.viewBounds = {
+  							north: nw[1],
+  							east:  se[1],
+  							south: se[0],
+  							west:  nw[0]
+  						};
+
 			      	if (!HTMLWidgets.shinyMode) {
 						    return;
 						  }


### PR DESCRIPTION
as per: https://github.com/SymbolixAU/mapdeck/issues/211

had a go at implementing the change - only tested quickly but seems to work and returns the below within `input$<map_id>_view_change`
```r
$mapBounds
$mapBounds$north
[1] 80.17871

$mapBounds$east
[1] -80.17871

$mapBounds$south
[1] 199.3359

$mapBounds$west
[1] -199.3359
```

I injected this into the viewState by adjusting:

```js

onViewStateChange: ({viewState}) => {

    // as per:
    // https://github.com/uber/deck.gl/issues/3344
    // https://github.com/SymbolixAU/mapdeck/issues/211
    const viewport = new WebMercatorViewport(viewState);
    const nw = viewport.unproject([0, 0]);
    const se = viewport.unproject([viewport.width, viewport.height]);

    viewState.viewBounds = {
        north: nw[1],
        east:  se[1],
        south: se[0],
        west:  nw[0]
    };

    if (!HTMLWidgets.shinyMode) {
        return;
    }
        Shiny.onInputChange(el.id + '_view_change', viewState);
}
```
I guess one alternative would be to add another shiny binding for each component for ease of use.



